### PR TITLE
Revert to depending on ruby 2.6, which is the version provided by macOS 11

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,9 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        ruby: [ '2.7' ]
+        ruby:
+          - 2.6
+          - 2.7
     steps:
       - uses: actions/checkout@v2
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,4 +9,4 @@ inherit_gem:
 AllCops:
   Exclude:
     - 'vendor/**/*'
-  TargetRubyVersion: 2.7
+  TargetRubyVersion: 2.6

--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 source "https://rubygems.org"
 
-ruby "2.7.2"
+ruby "~> 2.6"
 
 # None of these can actually be used in a development copy of dev
 # They are all for CI and tests

--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ single command: `git chain rebase`.
 ## Requirements
 
 - Git (of course)
-- System Ruby (`/usr/bin/ruby -v >= 2.3.7`) 
+- System Ruby (`/usr/bin/ruby -v >= 2.6.3`)
 
 ## Installation
 

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ type:
   - ruby
 
 up:
-  - ruby: 2.7.2
+  - ruby: 2.6.6
   - bundler
 
 test: "rake test"


### PR DESCRIPTION
There doesn't seem to be any problem with Ruby 2.7, but I want to avoid potential issues by making sure we stay  compatible.