### PR TITLE
Add a feature to list github links to open PRs with the correct bases

### DIFF
--- a/lib/git_chain/git.rb
+++ b/lib/git_chain/git.rb
@@ -61,6 +61,16 @@ module GitChain
         nil
       end
 
+      def remote_name(branch: "", dir: nil)
+        upstream_branch(branch: branch, dir: dir)&.split("/", 2)&.first
+      end
+
+      def remote_url(branch: "", dir: nil)
+        name = remote_name(branch: branch, dir: dir)
+        return if name.empty?
+        exec("remote", "get-url", name)
+      end
+
       def ancestor?(ancestor:, rev:, dir: nil)
         _, _, stat = capture3("merge-base", "--is-ancestor", ancestor, rev, dir: dir)
         stat.success?

--- a/lib/git_chain/util.rb
+++ b/lib/git_chain/util.rb
@@ -2,6 +2,7 @@
 module GitChain
   module Util
     autoload :EqualVariables, "git_chain/util/equal_variables"
+    autoload :Github, "git_chain/util/github"
     autoload :Output, "git_chain/util/output"
   end
 end

--- a/lib/git_chain/util/github.rb
+++ b/lib/git_chain/util/github.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+module GitChain
+  module Util
+    module Github
+      class << self
+        def parse_url(url)
+          # matches git@github.com:organization/project.git, https://github.com/organization/project.git
+          parsed_arg = url.match(
+            %r{
+              ^(?:(?:ssh://)?git@|https?://|git://) # git, http, https, and ssh protocols
+              github\.com[/:]                       # domain with either / (http) or : (ssh) separator
+              (.+?)/(.+?)(?:\.git)?$                # capture account/org and project; '.git' optional
+            }x
+          )
+          raise(ArgumentError, "invalid Github URL") unless parsed_arg
+
+          org = parsed_arg[1]
+          project = parsed_arg[2]
+          [url(org, project), org, project]
+        end
+
+        def url(org, project)
+          "https://github.com/#{org}/#{project}"
+        end
+      end
+    end
+  end
+end

--- a/test/git_chain/command/push_test.rb
+++ b/test/git_chain/command/push_test.rb
@@ -23,11 +23,14 @@ module GitChain
         capture_io do
           with_remote_test_repository("a-b-chain") do |remote_repo|
             assert_empty(Git.branches(dir: remote_repo))
+            assert_nil(Git.remote_name(branch: "a"))
 
             Push.new.call(["-u"])
             assert_equal(%w(a b).sort, Git.branches(dir: remote_repo).sort)
 
             assert_equal("test/a", Git.push_branch(branch: "a"))
+            assert_equal("test", Git.remote_name(branch: "a"))
+            assert_equal(remote_repo, Git.remote_url(branch: "a"))
           end
         end
       end

--- a/test/git_chain/util/github_test.rb
+++ b/test/git_chain/util/github_test.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+require "test_helper"
+
+module GitChain
+  module Util
+    class GithubTest < MiniTest::Test
+      def test_parse_url
+        %w(
+          git@github.com:Shopify/git-chain.git
+          ssh://git@github.com:Shopify/git-chain.git
+          https://github.com/Shopify/git-chain.git
+          http://github.com/Shopify/git-chain.git
+        ).each do |input|
+          url, org, repo = Github.parse_url(input)
+          assert_equal("https://github.com/Shopify/git-chain", url)
+          assert_equal("Shopify", org)
+          assert_equal("git-chain", repo)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
Ex:
```
$ git chain list
mailer [master branch1 branch2]

$ git chain list --github-links
mailer
  https://github.com/Shopify/git-chain/pull/new/master...branch1
  https://github.com/Shopify/git-chain/pull/new/branch1...branch2
```