### PR TITLE
Fix undefined local variable chain_name in branch.rb

### DIFF
--- a/lib/git_chain/commands/branch.rb
+++ b/lib/git_chain/commands/branch.rb
@@ -74,7 +74,7 @@ module GitChain
         branch_names = chain.branch_names
 
         if branch_names.empty?
-          raise(Abort, "Unable to insert, #{chain_name} does not exist yet") if options[:mode] == :insert
+          raise(Abort, "Unable to insert, #{options[:chain_name]} does not exist yet") if options[:mode] == :insert
           branch_names << start_point << branch_name
         else
           is_last = branch_names.last == start_point


### PR DESCRIPTION
Received the following error after running `git chain branch master <new branch> --insert`:

```
Traceback (most recent call last):
	3: from /usr/local/bin/git-chain:7:in `<main>'
	2: from /usr/local/share/git-chain/lib/git_chain/entry_point.rb:23:in `call'
	1: from /usr/local/share/git-chain/lib/git_chain/commands/command.rb:23:in `call'
/usr/local/share/git-chain/lib/git_chain/commands/branch.rb:77:in `run': undefined local variable or method `chain_name' for #<GitChain::Commands::Branch:0x00007fb4e80c6878> (NameError)
```