### PR TITLE
Handle cases where the last branch of a chain may not be pushed

### DIFF
--- a/lib/git_chain/commands/list.rb
+++ b/lib/git_chain/commands/list.rb
@@ -64,10 +64,10 @@ module GitChain
         branch_names = chain.branch_names
 
         # Assume that all branches in the chain have the same remote as the last branch
-        last = branch_names[-1]
-        remote_url = Git.remote_url(branch: last)
+        remote_url = chain.remote_url
         unless remote_url
-          raise(Abort, "No remote detected for branch {{info:#{last}}}. Did you push your branches first?")
+          puts("  {{error:Unable to detect remote}}")
+          return
         end
 
         begin

--- a/lib/git_chain/git.rb
+++ b/lib/git_chain/git.rb
@@ -67,7 +67,7 @@ module GitChain
 
       def remote_url(branch: "", dir: nil)
         name = remote_name(branch: branch, dir: dir)
-        return if name.empty?
+        return if name.to_s.empty?
         exec("remote", "get-url", name)
       end
 

--- a/lib/git_chain/models/chain.rb
+++ b/lib/git_chain/models/chain.rb
@@ -22,6 +22,15 @@ module GitChain
         "{{info:#{name}}} {{reset:[{{cyan:#{branch_names.join(" ")}}}]}}"
       end
 
+      def remote_url
+        remote = nil
+        branch_names.reverse_each do |branch|
+          remote = Git.remote_url(branch: branch)
+          break if remote
+        end
+        remote
+      end
+
       class << self
         def from_config(name)
           chains = Git.chains(chain_name: name)


### PR DESCRIPTION
Fixes:
```
/Users/seb/src/github.com/Shopify/git-chain/lib/git_chain/git.rb:70:in `remote_url': undefined method `empty?' for nil:NilClass (NoMethodError)
	from /Users/seb/src/github.com/Shopify/git-chain/lib/git_chain/commands/list.rb:68:in `print_github_links'
	from /Users/seb/src/github.com/Shopify/git-chain/lib/git_chain/commands/list.rb:47:in `block in run'
	from /Users/seb/src/github.com/Shopify/git-chain/lib/git_chain/commands/list.rb:46:in `each'
	from /Users/seb/src/github.com/Shopify/git-chain/lib/git_chain/commands/list.rb:46:in `run'
	from /Users/seb/src/github.com/Shopify/git-chain/lib/git_chain/commands/command.rb:23:in `call'
	from /Users/seb/src/github.com/Shopify/git-chain/lib/git_chain/entry_point.rb:23:in `call'
	from /Users/seb/bin/git-chain:7:in `<main>'
```

By falling back on the previous branch of the chain.