### PR TITLE
Bump ruby, rubocop, and github actions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,14 +12,17 @@ on:
 jobs:
   tests:
     name: Ruby ${{ matrix.ruby }} tests
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         ruby:
           - 2.6
           - 2.7
+          - 3.0
+          - 3.1
+          - 3.2
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Setup git
         run: |
@@ -39,13 +42,13 @@ jobs:
 
   lint:
     name: Lint
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - uses: ruby/setup-ruby@v1
         with:
-          ruby-version: 2.7
+          ruby-version: 2.6
 
       - name: Install dependencies
         run: bundle install

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -20,7 +20,7 @@ GEM
     rake (13.0.0)
     regexp_parser (2.1.1)
     rexml (3.2.5)
-    rubocop (1.11.0)
+    rubocop (1.13.0)
       parallel (~> 1.10)
       parser (>= 3.0.0.0)
       rainbow (>= 2.2.2, < 4.0)

--- a/dev.yml
+++ b/dev.yml
@@ -3,7 +3,7 @@ type:
   - ruby
 
 up:
-  - ruby: 2.6.6
+  - ruby: "2.6.10"
   - bundler
 
 test: "rake test"


### PR DESCRIPTION
Still stick to 2.6, which is the version provided by the latest macOS 

```
$ sw_vers
ProductName:		macOS
ProductVersion:		13.2
BuildVersion:		22D49

$ /usr/bin/ruby -v
ruby 2.6.10p210 (2022-04-12 revision 67958) [universal.arm64e-darwin22]
```