### PR TITLE
Fix branch insert messages

### DIFF
--- a/lib/git_chain/commands/branch.rb
+++ b/lib/git_chain/commands/branch.rb
@@ -19,7 +19,7 @@ module GitChain
           options[:chain_name] = name
         end
 
-        opts.on("-i", "--insert", "Insert in the middle of a chain (after current branch) instead of starting a new one") do
+        opts.on("-i", "--insert", "Insert in middle of chain (after current branch) instead of starting a new one") do
           options[:mode] = :insert
         end
 

--- a/lib/git_chain/commands/branch.rb
+++ b/lib/git_chain/commands/branch.rb
@@ -19,7 +19,7 @@ module GitChain
           options[:chain_name] = name
         end
 
-        opts.on("-i", "--insert", "Insert in the middle of a chain instead of starting a new one") do
+        opts.on("-i", "--insert", "Insert in the middle of a chain (after current branch) instead of starting a new one") do
           options[:mode] = :insert
         end
 
@@ -86,7 +86,7 @@ module GitChain
               puts_info("Appending {{info:#{branch_name}}} at the end of chain {{info:#{chain.name}}}")
               branch_names << branch_name
             else
-              puts_info("Inserting {{info:#{branch_name}}} before {{info:#{start_point}}} in chain #{chain.name}")
+              puts_info("Inserting {{info:#{branch_name}}} after {{info:#{start_point}}} in chain #{chain.name}")
               index = branch_names.index(start_point)
               branch_names.insert(index + 1, branch_name)
             end

--- a/lib/git_chain/commands/branch.rb
+++ b/lib/git_chain/commands/branch.rb
@@ -19,7 +19,7 @@ module GitChain
           options[:chain_name] = name
         end
 
-        opts.on("-i", "--insert", "Insert in middle of chain (after current branch) instead of starting a new one") do
+        opts.on("-i", "--insert", "Insert in the middle of a chain instead of starting a new one") do
           options[:mode] = :insert
         end
 


### PR DESCRIPTION
Improve help and output messages for `git chain branch --insert`

Current behavior without this PR:

![Screenshot 2023-02-10 at 1 46 22 PM](https://user-images.githubusercontent.com/5882840/218194504-e7b29380-ad23-4c89-9441-9900bda34706.png)
