### PR TITLE
Update bundler

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -62,4 +62,4 @@ DEPENDENCIES
   rubocop-shopify (~> 2.0.1)
 
 BUNDLED WITH
-   2.2.22
+   2.2.33


### PR DESCRIPTION
Pick up fix for https://github.com/rubygems/rubygems/security/advisories/GHSA-fj7f-vq84-fh43